### PR TITLE
update circle-ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2.1
+
+orbs:
+  solidusio_extensions: solidusio/extensions@volatile
+
+jobs:
+  run-specs-with-postgres:
+    executor: solidusio_extensions/postgres
+    steps:
+      - solidusio_extensions/run-tests
+  run-specs-with-mysql:
+    executor: solidusio_extensions/mysql
+    steps:
+      - solidusio_extensions/run-tests
+  lint-code:
+    executor: solidusio_extensions/sqlite-memory
+    steps:
+      - solidusio_extensions/lint-code
+
+workflows:
+  "Run specs on supported Solidus versions":
+    jobs:
+      - run-specs-with-postgres
+      - run-specs-with-mysql
+
+  "Weekly run specs against master":
+    triggers:
+      - schedule:
+          cron: "0 0 * * 4" # every Thursday
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - run-specs-with-postgres
+      - run-specs-with-mysql


### PR DESCRIPTION
update circle-ci config to use [solidus extensions orb](https://circleci.com/developer/orbs/orb/solidusio/extensions)

This config is used in official solidus extensions https://github.com/solidusio/solidus_auth_devise/blob/master/.circleci/config.yml